### PR TITLE
JSGEN-47 - fixes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "printWidth": 120
 }

--- a/__mocks__/svgr-mock.js
+++ b/__mocks__/svgr-mock.js
@@ -1,1 +1,2 @@
-module.exports = { ReactComponent: 'icon-mock' };
+export default 'icon-mock';
+export const ReactComponent = 'icon-component-mock';

--- a/__tests__/pages/__snapshots__/acropolis.test.js.snap
+++ b/__tests__/pages/__snapshots__/acropolis.test.js.snap
@@ -14,17 +14,13 @@ exports[`AcropolisPage page renders correctly 1`] = `
     animationStartValue={0}
     chip={
       <Chip
-        icon="icon-mock"
+        icon="icon-component-mock"
         onClick={[Function]}
       >
         What is this?
       </Chip>
     }
-    image={
-      Object {
-        "ReactComponent": "icon-mock",
-      }
-    }
+    image="icon-mock"
     indent={true}
     title="Acropolis Network"
   >
@@ -43,11 +39,7 @@ exports[`AcropolisPage page renders correctly 1`] = `
     <TestnetModal
       className=""
       closeModal={[Function]}
-      image={
-        Object {
-          "ReactComponent": "icon-mock",
-        }
-      }
+      image="icon-mock"
       isOpen={false}
       title="The Acropolis of Athens"
     >
@@ -85,42 +77,42 @@ exports[`AcropolisPage page renders correctly 1`] = `
         items={
           Array [
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "title": "Participation Payout",
               "value": "$1576",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "validatorsCount",
               "title": "Active Validators",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "blockHeight",
               "title": "Block Height",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "councilStage",
               "title": "Council Election Stage",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "membershipsMembers",
               "title": "Memberships",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "forumPosts",
               "title": "Forum Posts",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "mediaFiles",
               "title": "Platform Content Files",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "rolesProviders",
               "title": "Active Storage Providers",
             },
@@ -142,7 +134,7 @@ exports[`AcropolisPage page renders correctly 1`] = `
           className=""
           disabled={false}
           href="https://github.com/Joystream/joystream/tree/master/testnets/acropolis/specification"
-          image="icon-mock"
+          image="icon-component-mock"
           target="_blank"
           title="Full Specifications"
         >
@@ -152,7 +144,7 @@ exports[`AcropolisPage page renders correctly 1`] = `
           className=""
           disabled={false}
           href="https://github.com/Joystream/joystream/tree/master/testnets/acropolis"
-          image="icon-mock"
+          image="icon-component-mock"
           target="_blank"
           title="Release Plan"
         >
@@ -243,21 +235,21 @@ exports[`AcropolisPage page renders correctly 1`] = `
             Array [
               Object {
                 "hasLabel": false,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "validatorsCount",
                 "title": "Validator",
                 "to": "/roles#validator",
               },
               Object {
                 "hasLabel": false,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "councilMembersCount",
                 "title": "Council Member",
                 "to": "/roles#council-member",
               },
               Object {
                 "hasLabel": true,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "storageProviders",
                 "title": "Storage Provider",
                 "to": "/roles#storage-provider",
@@ -288,7 +280,7 @@ exports[`AcropolisPage page renders correctly 1`] = `
         highlighted={false}
         to="/athens"
       >
-        <icon-mock />
+        <icon-component-mock />
          Explore previous testnet
       </Link>
     </p>

--- a/__tests__/pages/__snapshots__/acropolis.test.js.snap
+++ b/__tests__/pages/__snapshots__/acropolis.test.js.snap
@@ -3,7 +3,7 @@
 exports[`AcropolisPage page renders correctly 1`] = `
 <BaseLayout>
   <SiteMetadata
-    description="Explore the upcoming Acropolis Testnet"
+    description="Explore the Acropolis Testnet"
     image="test-file-stub"
     lang="en"
     meta={Array []}
@@ -27,7 +27,7 @@ exports[`AcropolisPage page renders correctly 1`] = `
     <p
       className="AcropolisPage__hero-paragraph"
     >
-      Explore available roles and pick the one that suits you the most. Influence platforms development earning Monero in the process.
+      Explore available roles and pick the one that suits you the best. Influence the platform's development earning Monero in the process.
     </p>
     <HeroCard
       content={null}

--- a/__tests__/pages/__snapshots__/athens.test.js.snap
+++ b/__tests__/pages/__snapshots__/athens.test.js.snap
@@ -14,17 +14,13 @@ exports[`AthensPage page renders correctly 1`] = `
     animationStartValue={0}
     chip={
       <Chip
-        icon="icon-mock"
+        icon="icon-component-mock"
         onClick={[Function]}
       >
         What is this?
       </Chip>
     }
-    image={
-      Object {
-        "ReactComponent": "icon-mock",
-      }
-    }
+    image="icon-mock"
     indent={true}
     title="Athens Network"
   >
@@ -57,11 +53,7 @@ exports[`AthensPage page renders correctly 1`] = `
     <TestnetModal
       className=""
       closeModal={[Function]}
-      image={
-        Object {
-          "ReactComponent": "icon-mock",
-        }
-      }
+      image="icon-mock"
       isOpen={false}
       title="Owl of Athena"
     >
@@ -99,22 +91,22 @@ exports[`AthensPage page renders correctly 1`] = `
         items={
           Array [
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "title": "Participation Payout",
               "value": "$1576",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "validatorsCount",
               "title": "Active Validators",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "mediaFiles",
               "title": "Platform Content Files",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "blockHeight",
               "title": "Block Height",
             },
@@ -135,7 +127,7 @@ exports[`AthensPage page renders correctly 1`] = `
         <Pane
           className=""
           disabled={true}
-          image="icon-mock"
+          image="icon-component-mock"
           title="Full Specifications"
         >
           No specifications was published for Athens.
@@ -144,7 +136,7 @@ exports[`AthensPage page renders correctly 1`] = `
           className=""
           disabled={false}
           href="https://github.com/Joystream/joystream/tree/master/testnets/athens"
-          image="icon-mock"
+          image="icon-component-mock"
           target="_blank"
           title="Release Plan"
         >
@@ -241,7 +233,7 @@ exports[`AthensPage page renders correctly 1`] = `
             Array [
               Object {
                 "hasLabel": false,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "validatorsCount",
                 "title": "Validator",
                 "to": "/roles#validator",
@@ -249,7 +241,7 @@ exports[`AthensPage page renders correctly 1`] = `
               },
               Object {
                 "hasLabel": false,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "councilMembersCount",
                 "title": "Council Member",
                 "to": "/roles#council-member",
@@ -257,7 +249,7 @@ exports[`AthensPage page renders correctly 1`] = `
               },
               Object {
                 "hasLabel": true,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "storageProviders",
                 "title": "Storage Provider",
                 "to": "/roles#storage-provider",
@@ -289,7 +281,7 @@ exports[`AthensPage page renders correctly 1`] = `
         highlighted={false}
         to="/sparta"
       >
-        <icon-mock />
+        <icon-component-mock />
          Explore previous testnet
       </Link>
     </p>

--- a/__tests__/pages/__snapshots__/athens.test.js.snap
+++ b/__tests__/pages/__snapshots__/athens.test.js.snap
@@ -3,7 +3,7 @@
 exports[`AthensPage page renders correctly 1`] = `
 <BaseLayout>
   <SiteMetadata
-    description="Explore the live Athens testnet"
+    description="Explore Athens testnet"
     image="test-file-stub"
     lang="en"
     meta={Array []}
@@ -27,7 +27,7 @@ exports[`AthensPage page renders correctly 1`] = `
     <p
       className="AthensPage__hero-paragraph"
     >
-      Explore available roles and pick the one that suits you the most. Influence platforms development earning Monero in the process.
+      Explore available roles and pick the one that suits you the best. Influence the platform's development earning Monero in the process.
     </p>
     <HeroCard
       content={null}

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -13,11 +13,7 @@ exports[`IndexPage page renders correctly 1`] = `
     animationEndValue={-40}
     animationStartValue={0}
     chip={null}
-    image={
-      Object {
-        "ReactComponent": "icon-mock",
-      }
-    }
+    image="icon-mock"
     indent={false}
     title="A user governed video platform"
   >
@@ -67,17 +63,13 @@ exports[`IndexPage page renders correctly 1`] = `
     <TestnetItem
       button={
         Object {
-          "label": "Explore acropolis",
+          "label": "Explore Acropolis",
           "to": "/acropolis",
         }
       }
       className=""
       date={null}
-      image={
-        Object {
-          "ReactComponent": "icon-mock",
-        }
-      }
+      image="icon-mock"
       title="Acropolis Tesnet"
     >
       Acropolis is our fourth testnet, with much improved
@@ -107,42 +99,42 @@ exports[`IndexPage page renders correctly 1`] = `
       items={
         Array [
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "title": "Participation Payout",
             "value": "$1576",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "validatorsCount",
             "title": "Active Validators",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "blockHeight",
             "title": "Block Height",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "councilStage",
             "title": "Council Election Stage",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "membershipsMembers",
             "title": "Memberships",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "forumPosts",
             "title": "Forum Posts",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "mediaFiles",
             "title": "Platform Content Files",
           },
           Object {
-            "image": "icon-mock",
+            "image": "icon-component-mock",
             "key": "rolesProviders",
             "title": "Active Storage Providers",
           },
@@ -164,6 +156,20 @@ exports[`IndexPage page renders correctly 1`] = `
         Participate and Earn Monero
       </Button>
     </Analytics>
+    <TestnetItem
+      button={
+        Object {
+          "label": "Explore Rome",
+          "to": "/rome",
+        }
+      }
+      className=""
+      date="2019/11/4 11:00"
+      image="icon-mock"
+      title="Rome Tesnet"
+    >
+      Rome is our fifth testnet, and we are introducing new roles for you to try out.
+    </TestnetItem>
   </LayoutWrapper>
   <LayoutWrapper
     className=""
@@ -178,7 +184,7 @@ exports[`IndexPage page renders correctly 1`] = `
       <Subheader
         className=""
         content="learn more, join a role and subscribe for more"
-        icon="icon-mock"
+        icon="icon-component-mock"
         title="Active roles on the current testnet"
       />
       <ColumnsLayout
@@ -198,21 +204,21 @@ exports[`IndexPage page renders correctly 1`] = `
             Array [
               Object {
                 "hasLabel": false,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "validatorsCount",
                 "title": "Validator",
                 "to": "/roles#validator",
               },
               Object {
                 "hasLabel": false,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "councilMembersCount",
                 "title": "Council Member",
                 "to": "/roles#council-member",
               },
               Object {
                 "hasLabel": true,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "storageProviders",
                 "title": "Storage Provider",
                 "to": "/roles#storage-provider",
@@ -224,7 +230,7 @@ exports[`IndexPage page renders correctly 1`] = `
       <Subheader
         className=""
         content="choose a role, learn more and subscribe to get updated"
-        icon="icon-mock"
+        icon="icon-component-mock"
         title="Roles coming in future testnets"
       />
       <ColumnsLayout
@@ -243,47 +249,47 @@ exports[`IndexPage page renders correctly 1`] = `
           roles={
             Array [
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Membership Screener",
                 "to": "/roles#membership-screener",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Membership Curator",
                 "to": "/roles",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Content Curator",
                 "to": "/roles#content-curator",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Content Creator",
                 "to": "/roles#content-creator",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Bandwidth Provider",
                 "to": "/roles#bandwidth-provider",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Discovery Provider",
                 "to": "/roles#discovery-provider",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Live Streaming Provider",
                 "to": "/roles#live-streaming-provider",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Builder",
                 "to": "/roles#builder",
               },
               Object {
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "title": "Communication Moderator",
                 "to": "/roles#communication-moderator",
               },

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`IndexPage page renders correctly 1`] = `
 <BaseLayout>
   <SiteMetadata
-    description="Earn monero to participate on our testnets!"
+    description="Earn monero for participating on our testnets!"
     image="test-file-stub"
     lang="en"
     meta={Array []}
@@ -20,7 +20,9 @@ exports[`IndexPage page renders correctly 1`] = `
     <p
       className="IndexPage__hero-paragraph"
     >
-      Earn Monero by participating in the current Athens testnet
+      Earn Monero by participating in the current 
+      Acropolis
+       testnet
     </p>
     <div
       className="IndexPage__hero-group"
@@ -63,14 +65,14 @@ exports[`IndexPage page renders correctly 1`] = `
     <TestnetItem
       button={
         Object {
-          "label": "Explore acropolis",
+          "label": "Explore Acropolis",
           "to": "/acropolis",
         }
       }
       className=""
       date={null}
       image="icon-mock"
-      title="Acropolis Tesnet"
+      title="Acropolis Testnet"
     >
       Acropolis is our fourth testnet, with much improved
        
@@ -144,7 +146,7 @@ exports[`IndexPage page renders correctly 1`] = `
       <Button
         className=""
         disabled={false}
-        href="https://blog.joystream.org/athens-incentives/"
+        href="https://blog.joystream.org/acropolis-incentives/"
         large={false}
         light={false}
         onClick={null}

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -63,7 +63,7 @@ exports[`IndexPage page renders correctly 1`] = `
     <TestnetItem
       button={
         Object {
-          "label": "Explore Acropolis",
+          "label": "Explore acropolis",
           "to": "/acropolis",
         }
       }
@@ -156,20 +156,6 @@ exports[`IndexPage page renders correctly 1`] = `
         Participate and Earn Monero
       </Button>
     </Analytics>
-    <TestnetItem
-      button={
-        Object {
-          "label": "Explore Rome",
-          "to": "/rome",
-        }
-      }
-      className=""
-      date="2019/11/4 11:00"
-      image="icon-mock"
-      title="Rome Tesnet"
-    >
-      Rome is our fifth testnet, and we are introducing new roles for you to try out.
-    </TestnetItem>
   </LayoutWrapper>
   <LayoutWrapper
     className=""

--- a/__tests__/pages/__snapshots__/roles.test.js.snap
+++ b/__tests__/pages/__snapshots__/roles.test.js.snap
@@ -13,11 +13,7 @@ exports[`RolesPage page renders correctly 1`] = `
     animationEndValue={-40}
     animationStartValue={0}
     chip={null}
-    image={
-      Object {
-        "ReactComponent": "icon-mock",
-      }
-    }
+    image="icon-mock"
     indent={false}
     title="Discover various roles on the platform"
   >
@@ -40,7 +36,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "validator",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "The Joystream platform state lives on a blockchain consensus system.
     This consensus system is a variant of classical BFT consensus combined
     with Proof-of-Stake to determine voting power. A validator is an actor
@@ -67,7 +63,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "council-member",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "At the heart of the governance process on the platform is the proposal system,
         which allows anyone to submit some suggestion for changing the state or
         policy of the platform in some way. These proposals are processed and voted on by a council,
@@ -91,7 +87,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "storage-provider",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "There are critical platform assets that do not live on the blockchain,
         such as images and content media. The integrity of these assets is secured by the chain,
         but a separate set of storage and distribution nodes enabled uploading and downloading of
@@ -115,7 +111,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "membership-screener",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "A membership is an integrated representation of identifying information
         and associated activities of an actor on the platform. The direct way of
         establishing membership will be to simply pay a one time fee. However, since its
@@ -160,7 +156,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "membership-curator",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": <React.Fragment>
                 A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described 
                 <Link
@@ -207,7 +203,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "content-curator",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "All of the media content published on the platform lives in an on chain content directory.
          There is a range of different content types, and each type has a schema for a rich
          description of its structure, function and policies. For the effective use of of content,
@@ -241,7 +237,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "content-creator",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "As a video platform, one of the most important platform assets is the content published
         on the platform. Since video is such a flexible media type, which can encompass a wide
         range of content categories, it is the primary focus, but the intention is to support
@@ -259,7 +255,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "bandwidth-provider",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "There are critical platform assets that do not live on the blockchain, such as images
       and content media. The integrity of these assets is secured by the chain, but a separate
       set of storage and distribution nodes enabled uploading and downloading of such data.
@@ -280,7 +276,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "discovery-provider",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "All of the content on the platform is in a designated content directory, and effectively navigating
         this directory requires a full copy of this directory. Moreover, in order to do things like search and
         context based recommendations one needs to apply some sort of heuristic on top of this directory,
@@ -313,7 +309,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "live-streaming-provider",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "The platform supports live video, allowing publisher to distribute content as it is created.
       The live streaming providers are responsible for directly, or indirectly from peer
       providers, taking a (transcoded) stream from the source publisher, and relaying it to end users.",
@@ -332,7 +328,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "builder",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": <React.Fragment>
                 The platform runtime, tools, infrastructure software and user facing applications are all meant to evolve over time. A diverse set of contributors are required to facilitate this, including
                 <br />
@@ -375,7 +371,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Object {
               "formAction": "",
               "id": "communication-moderator",
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "overview": "
           The platform will have multiple ways of facilitating easy and secure public, and private,
            communication and information sharing among members. In particular, there will be both
@@ -414,7 +410,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="validator"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="The Joystream platform state lives on a blockchain consensus system.
     This consensus system is a variant of classical BFT consensus combined
     with Proof-of-Stake to determine voting power. A validator is an actor
@@ -455,7 +451,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="council-member"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="At the heart of the governance process on the platform is the proposal system,
         which allows anyone to submit some suggestion for changing the state or
         policy of the platform in some way. These proposals are processed and voted on by a council,
@@ -493,7 +489,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="storage-provider"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="There are critical platform assets that do not live on the blockchain,
         such as images and content media. The integrity of these assets is secured by the chain,
         but a separate set of storage and distribution nodes enabled uploading and downloading of
@@ -529,7 +525,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="membership-screener"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="A membership is an integrated representation of identifying information
         and associated activities of an actor on the platform. The direct way of
         establishing membership will be to simply pay a one time fee. However, since its
@@ -588,7 +584,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="membership-curator"
-          image="icon-mock"
+          image="icon-component-mock"
           overview={
             <React.Fragment>
               A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described 
@@ -651,7 +647,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="content-curator"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="All of the media content published on the platform lives in an on chain content directory.
          There is a range of different content types, and each type has a schema for a rich
          description of its structure, function and policies. For the effective use of of content,
@@ -699,7 +695,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="content-creator"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="As a video platform, one of the most important platform assets is the content published
         on the platform. Since video is such a flexible media type, which can encompass a wide
         range of content categories, it is the primary focus, but the intention is to support
@@ -731,7 +727,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="bandwidth-provider"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="There are critical platform assets that do not live on the blockchain, such as images
       and content media. The integrity of these assets is secured by the chain, but a separate
       set of storage and distribution nodes enabled uploading and downloading of such data.
@@ -766,7 +762,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="discovery-provider"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="All of the content on the platform is in a designated content directory, and effectively navigating
         this directory requires a full copy of this directory. Moreover, in order to do things like search and
         context based recommendations one needs to apply some sort of heuristic on top of this directory,
@@ -813,7 +809,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="live-streaming-provider"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="The platform supports live video, allowing publisher to distribute content as it is created.
       The live streaming providers are responsible for directly, or indirectly from peer
       providers, taking a (transcoded) stream from the source publisher, and relaying it to end users."
@@ -846,7 +842,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="builder"
-          image="icon-mock"
+          image="icon-component-mock"
           overview={
             <React.Fragment>
               The platform runtime, tools, infrastructure software and user facing applications are all meant to evolve over time. A diverse set of contributors are required to facilitate this, including
@@ -905,7 +901,7 @@ exports[`RolesPage page renders correctly 1`] = `
           className=""
           formAction=""
           id="communication-moderator"
-          image="icon-mock"
+          image="icon-component-mock"
           overview="
           The platform will have multiple ways of facilitating easy and secure public, and private,
            communication and information sharing among members. In particular, there will be both

--- a/__tests__/pages/__snapshots__/roles.test.js.snap
+++ b/__tests__/pages/__snapshots__/roles.test.js.snap
@@ -20,7 +20,7 @@ exports[`RolesPage page renders correctly 1`] = `
     <p
       className="RolesPage__hero-paragraph"
     >
-      Explore available roles and pick the one that suits you the most. Influence platforms development earning Monero in the process.
+      Explore available roles and pick the one that suits you the best. Influence the platform's development earning Monero in the process.
     </p>
   </Hero>
   <LayoutWrapper
@@ -79,7 +79,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "responsibilites": Array [
                 "Discuss the meaning and merits of incoming proposals, covering a broad range of topics",
                 "Vote on proposals",
-                "Represent the community members and your constituency to make day to day operations decisions",
+                "Represent the community members and your constituency to make day-to-day operations decisions",
               ],
               "title": "Council Member",
               "tutorialLink": "https://github.com/Joystream/helpdesk/tree/master/roles/council-members",
@@ -99,7 +99,7 @@ exports[`RolesPage page renders correctly 1`] = `
                 "Hold sufficient amount of the native platform token to put at stake",
               ],
               "responsibilites": Array [
-                "Run an and maintain storage nodes that store very large quantities of static data,
+                "Run and maintain storage nodes that store very large quantities of static data,
         synchronize with other storage nodes, shares data with distributors, and accepts
         inbound uploads from end users",
               ],
@@ -130,8 +130,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "responsibilites": Array [
                 "Run and maintain screening nodes that are always available and performant",
                 <React.Fragment>
-                  Collaborate with
-                   
+                  Collaborate with 
                   <Link
                     className=""
                     highlighted={false}
@@ -158,7 +157,8 @@ exports[`RolesPage page renders correctly 1`] = `
               "id": "membership-curator",
               "image": "icon-component-mock",
               "overview": <React.Fragment>
-                A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described 
+                A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described
+                 
                 <Link
                   className=""
                   highlighted={false}
@@ -186,8 +186,8 @@ exports[`RolesPage page renders correctly 1`] = `
                   >
                      Screeners
                   </Link>
+                   and
                    
-                  and 
                   <Link
                     className=""
                     highlighted={false}
@@ -269,7 +269,7 @@ exports[`RolesPage page renders correctly 1`] = `
                 "Hold sufficient amount of the native platform token to put at stake",
               ],
               "responsibilites": Array [
-                "Run and maintain distributor nodes that delivers large volumes of upstream data to a large number of simultaneous end users",
+                "Run and maintain distributor nodes that deliver large volumes of upstream data to a large number of simultaneous end users",
               ],
               "title": "Bandwidth Provider",
             },
@@ -320,8 +320,7 @@ exports[`RolesPage page renders correctly 1`] = `
                 "Hold sufficient amount of the native platform token to put at stake",
               ],
               "responsibilites": Array [
-                "Run and maintain live streaming nodes that delivers large volumes of upstream data to a large number of
-         simultaneous end users",
+                "Run and maintain live streaming nodes that deliver large volumes of upstream data to a large number of simultaneous end users",
               ],
               "title": "Live Streaming Provider",
             },
@@ -470,7 +469,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Array [
               "Discuss the meaning and merits of incoming proposals, covering a broad range of topics",
               "Vote on proposals",
-              "Represent the community members and your constituency to make day to day operations decisions",
+              "Represent the community members and your constituency to make day-to-day operations decisions",
             ]
           }
           title="Council Member"
@@ -504,7 +503,7 @@ exports[`RolesPage page renders correctly 1`] = `
           }
           responsibilites={
             Array [
-              "Run an and maintain storage nodes that store very large quantities of static data,
+              "Run and maintain storage nodes that store very large quantities of static data,
         synchronize with other storage nodes, shares data with distributors, and accepts
         inbound uploads from end users",
             ]
@@ -547,8 +546,7 @@ exports[`RolesPage page renders correctly 1`] = `
             Array [
               "Run and maintain screening nodes that are always available and performant",
               <React.Fragment>
-                Collaborate with
-                 
+                Collaborate with 
                 <Link
                   className=""
                   highlighted={false}
@@ -587,7 +585,8 @@ exports[`RolesPage page renders correctly 1`] = `
           image="icon-component-mock"
           overview={
             <React.Fragment>
-              A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described 
+              A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described
+               
               <Link
                 className=""
                 highlighted={false}
@@ -619,8 +618,8 @@ exports[`RolesPage page renders correctly 1`] = `
                 >
                    Screeners
                 </Link>
+                 and
                  
-                and 
                 <Link
                   className=""
                   highlighted={false}
@@ -744,7 +743,7 @@ exports[`RolesPage page renders correctly 1`] = `
           }
           responsibilites={
             Array [
-              "Run and maintain distributor nodes that delivers large volumes of upstream data to a large number of simultaneous end users",
+              "Run and maintain distributor nodes that deliver large volumes of upstream data to a large number of simultaneous end users",
             ]
           }
           title="Bandwidth Provider"
@@ -823,8 +822,7 @@ exports[`RolesPage page renders correctly 1`] = `
           }
           responsibilites={
             Array [
-              "Run and maintain live streaming nodes that delivers large volumes of upstream data to a large number of
-         simultaneous end users",
+              "Run and maintain live streaming nodes that deliver large volumes of upstream data to a large number of simultaneous end users",
             ]
           }
           title="Live Streaming Provider"

--- a/__tests__/pages/__snapshots__/sparta.test.js.snap
+++ b/__tests__/pages/__snapshots__/sparta.test.js.snap
@@ -14,17 +14,13 @@ exports[`SpartaPage page renders correctly 1`] = `
     animationStartValue={70}
     chip={
       <Chip
-        icon="icon-mock"
+        icon="icon-component-mock"
         onClick={[Function]}
       >
         What is this?
       </Chip>
     }
-    image={
-      Object {
-        "ReactComponent": "icon-mock",
-      }
-    }
+    image="icon-mock"
     indent={true}
     title="Sparta Network"
   >
@@ -36,10 +32,13 @@ exports[`SpartaPage page renders correctly 1`] = `
     <HeroCard
       content="
   ### FAILURE IDENTIFIED
-  On Friday the 29th of March, the Sparta network went down due to a [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) that we had not pulled down before release.
 
+  On Friday the 29th of March, the Sparta network went down due to a 
+  [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) 
+  that we had not pulled down before release. 
+  
   More details can be found in this [blog post](https://blog.joystream.org/sparta-sacked/).
-  "
+"
       counterTitle=""
       date={null}
       error={true}
@@ -48,11 +47,7 @@ exports[`SpartaPage page renders correctly 1`] = `
     <TestnetModal
       className=""
       closeModal={[Function]}
-      image={
-        Object {
-          "ReactComponent": "icon-mock",
-        }
-      }
+      image="icon-mock"
       isOpen={false}
       title="Helmet of Sparta"
     >
@@ -90,22 +85,22 @@ exports[`SpartaPage page renders correctly 1`] = `
         items={
           Array [
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "title": "Participation Payout",
               "value": "$1576",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "validatorsCount",
               "title": "Active Validators",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "membershipsMembers",
               "title": "Memberships",
             },
             Object {
-              "image": "icon-mock",
+              "image": "icon-component-mock",
               "key": "blockHeight",
               "title": "Block Height",
             },
@@ -177,7 +172,7 @@ exports[`SpartaPage page renders correctly 1`] = `
             Array [
               Object {
                 "hasLabel": true,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "validatorsCount",
                 "title": "Validator",
                 "to": "/roles#validator",
@@ -185,7 +180,7 @@ exports[`SpartaPage page renders correctly 1`] = `
               },
               Object {
                 "hasLabel": true,
-                "image": "icon-mock",
+                "image": "icon-component-mock",
                 "key": "councilMembersCount",
                 "title": "Council Member",
                 "to": "/roles#council-member",
@@ -206,12 +201,11 @@ exports[`SpartaPage page renders correctly 1`] = `
       <strong>
         Sparta was a prominent city-state in Ancient Greece.
       </strong>
-       In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution.
+       
+      In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution.
       <br />
       <br />
       We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law, however draconian by modern standard.
-      <br />
-      <br />
     </p>
   </MapInfo>
 </BaseLayout>

--- a/__tests__/pages/__snapshots__/sparta.test.js.snap
+++ b/__tests__/pages/__snapshots__/sparta.test.js.snap
@@ -27,7 +27,7 @@ exports[`SpartaPage page renders correctly 1`] = `
     <p
       className="SpartaPage__hero-paragraph"
     >
-      Explore available roles and pick the one that suits you the most. Influence platforms development earning Monero in the process.
+      Explore available roles and pick the one that suits you the best. Influence the platform's development earning Monero in the process.
     </p>
     <HeroCard
       content="
@@ -131,7 +131,7 @@ exports[`SpartaPage page renders correctly 1`] = `
                 >
                   Council Members
                 </Link>
-                 to represent their interest in day to day operations was a major goal for us.
+                 to represent their interest in day-to-day operations was a major goal for us.
               </React.Fragment>,
               "title": "Build and release a blockchain with a working Council",
             },
@@ -201,8 +201,7 @@ exports[`SpartaPage page renders correctly 1`] = `
       <strong>
         Sparta was a prominent city-state in Ancient Greece.
       </strong>
-       
-      In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution.
+       In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution.
       <br />
       <br />
       We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law, however draconian by modern standard.

--- a/__tests__/pages/acropolis.test.js
+++ b/__tests__/pages/acropolis.test.js
@@ -1,13 +1,8 @@
-import React from 'react';
-import { shallow, configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-
+import React from 'react';
 import { AcropolisPage } from '../../src/pages/acropolis';
-
 import testContent from '../../__mocks__/data/testContent';
-
-configure({ adapter: new Adapter() });
 
 describe('AcropolisPage page', () => {
   it('renders correctly', () => {

--- a/__tests__/pages/athens.test.js
+++ b/__tests__/pages/athens.test.js
@@ -1,13 +1,8 @@
-import React from 'react';
-import { shallow, configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-
+import React from 'react';
 import { AthensPage } from '../../src/pages/athens';
-
 import testContent from '../../__mocks__/data/testContent';
-
-configure({ adapter: new Adapter() });
 
 describe('AthensPage page', () => {
   it('renders correctly', () => {

--- a/__tests__/pages/index.test.js
+++ b/__tests__/pages/index.test.js
@@ -1,13 +1,8 @@
-import React from 'react';
-import { shallow, configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-
+import React from 'react';
 import { IndexPage } from '../../src/pages';
-
 import testContent from '../../__mocks__/data/testContent';
-
-configure({ adapter: new Adapter() });
 
 describe('IndexPage page', () => {
   it('renders correctly', () => {

--- a/__tests__/pages/privacy-policy.test.js
+++ b/__tests__/pages/privacy-policy.test.js
@@ -1,11 +1,7 @@
-import React from 'react';
-import { shallow, configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-
+import React from 'react';
 import PrivacyPolicyPage from '../../src/pages/privacy-policy';
-
-configure({ adapter: new Adapter() });
 
 describe('PrivacyPolicyPage page', () => {
   it('renders correctly', () => {

--- a/__tests__/pages/roles.test.js
+++ b/__tests__/pages/roles.test.js
@@ -1,12 +1,8 @@
-import React from 'react';
-import { shallow, configure } from 'enzyme';
-import 'intersection-observer';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-
+import 'intersection-observer';
+import React from 'react';
 import RolesPage from '../../src/pages/roles';
-
-configure({ adapter: new Adapter() });
 
 describe('RolesPage page', () => {
   it('renders correctly', () => {

--- a/__tests__/pages/sparta.test.js
+++ b/__tests__/pages/sparta.test.js
@@ -1,13 +1,8 @@
-import React from 'react';
-import { shallow, configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
-
+import React from 'react';
 import { SpartaPage } from '../../src/pages/sparta';
-
 import testContent from '../../__mocks__/data/testContent';
-
-configure({ adapter: new Adapter() });
 
 describe('SpartaPage page', () => {
   it('renders correctly', () => {

--- a/__tests__/setupTests.js
+++ b/__tests__/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,11 +8,11 @@ module.exports = {
       '<rootDir>/__mocks__/file-mock.js',
     '.+\\.(svg)$': '<rootDir>/__mocks__/svgr-mock.js',
   },
-  testPathIgnorePatterns: ['node_modules', '.cache'],
+  testPathIgnorePatterns: ['node_modules', '.cache', 'setupTests.js'],
   transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],
   globals: {
     __PATH_PREFIX__: '',
   },
   testURL: 'http://localhost',
-  setupFiles: ['<rootDir>/loadershim.js'],
+  setupFiles: ['<rootDir>/loadershim.js', '<rootDir>/__tests__/setupTests.js'],
 };

--- a/src/components/Footer/data.js
+++ b/src/components/Footer/data.js
@@ -1,6 +1,5 @@
 import { ReactComponent as TwitterIcon } from '../../assets/svg/twitter.svg';
 import { ReactComponent as GithubIcon } from '../../assets/svg/github.svg';
-import { ReactComponent as RocketChatIcon } from '../../assets/svg/rocketchat.svg';
 import { ReactComponent as TelegramIcon } from '../../assets/svg/telegram.svg';
 
 const links = [
@@ -13,7 +12,6 @@ const links = [
 const socialMedias = [
   { icon: TwitterIcon, href: 'https://twitter.com/JoyStreamApp', name: 'Twitter' },
   { icon: GithubIcon, href: 'https://github.com/Joystream', name: 'Github' },
-  { icon: RocketChatIcon, href: 'https://chat.joystream.org/home', name: 'Chat' },
   { icon: TelegramIcon, href: 'https://t.me/joinchat/CNyeUxHD9H56m3e_44hXIA', name: 'Telegram' },
 ];
 

--- a/src/components/Hero/hero.stories.js
+++ b/src/components/Hero/hero.stories.js
@@ -9,6 +9,7 @@ import Button from '../Button';
 import Link from '../Link';
 import HeroCard from '../HeroCard';
 
+import { sharedData } from '../../data/pages';
 import Hero from './';
 import './hero.stories.scss';
 
@@ -22,15 +23,12 @@ storiesOf('Section|Hero', module)
   })
   .add('plain content with an image', () => (
     <Hero image={masksImage} title="Discover various roles on the platform">
-      <p className="HeroStory__paragraph">
-        Explore available roles and pick the one that suits you the most. Influence platforms development earning Monero
-        in the process.
-      </p>
+      <p className="HeroStory__paragraph">{sharedData.rolesDescription}</p>
     </Hero>
   ))
   .add('custom content', () => (
     <Hero image={platformImage} title="A user governed video platform">
-      <p className="HeroStory__paragraph">Earn Monero by participating in the current Athens testnet</p>
+      <p className="HeroStory__paragraph">Earn Monero by participating in the current testnet</p>
       <div className="HeroStory__group">
         <Button secondary className="HeroStory__button">
           Earn Monero
@@ -85,10 +83,7 @@ storiesOf('Section|Hero', module)
     'with indent and counter',
     () => (
       <Hero title="Acropolis Network" image={acropolisImage} indent>
-        <p className="HeroStory__paragraph">
-          Explore available roles and pick the one that suits you the most. Influence platforms development earning
-          Monero in the process.
-        </p>
+        <p className="HeroStory__paragraph">{sharedData.rolesDescription}</p>
         <HeroCard date={unfinishedDate} />
       </Hero>
     ),

--- a/src/components/RoleCard/index.js
+++ b/src/components/RoleCard/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, number, bool, oneOf, oneOfType } from 'prop-types';
+import { string, func, number, bool, oneOf, oneOfType } from 'prop-types';
 import cn from 'classnames';
 
 import Link from '../Link';
@@ -12,7 +12,7 @@ import './style.scss';
 
 const propTypes = {
   ...linkPropTypes,
-  image: string.isRequired,
+  image: func.isRequired,
   title: string.isRequired,
   count: oneOfType([string, number]),
   className: string,

--- a/src/components/RoleCard/roleCard.stories.js
+++ b/src/components/RoleCard/roleCard.stories.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import centered from '@storybook/addon-centered/react';
 
-import validatorsImage from '../../assets/svg/active-validators.svg';
+import { ReactComponent as ValidatorsImage } from '../../assets/svg/active-validators.svg';
 
 import RoleCard from './';
 
 const defaultProps = {
-  image: validatorsImage,
+  image: ValidatorsImage,
   title: 'Validator',
   count: 20,
   to: '/',
@@ -23,4 +23,4 @@ storiesOf('Components|RoleCard', module)
   .add('type current (default)', () => <RoleCard {...defaultProps} />)
   .add('type migration', () => <RoleCard type="migration" {...defaultProps} />)
   .add('type most', () => <RoleCard type="most" {...defaultProps} />)
-  .add('small', () => <RoleCard to="/" type="most" image={validatorsImage} title="Validator" />);
+  .add('small', () => <RoleCard to="/" type="most" image={ValidatorsImage} title="Validator" />);

--- a/src/components/RoleList/roleList.stories.js
+++ b/src/components/RoleList/roleList.stories.js
@@ -4,36 +4,36 @@ import centered from '@storybook/addon-centered/react';
 
 import RoleList from './';
 
-import validatorsImage from '../../assets/svg/active-validators.svg';
-import storageImage from '../../assets/svg/storage.svg';
-import memberImage from '../../assets/svg/council-member.svg';
+import { ReactComponent as ValidatorsImage } from '../../assets/svg/active-validators.svg';
+import { ReactComponent as StorageImage } from '../../assets/svg/storage.svg';
+import { ReactComponent as MemberImage } from '../../assets/svg/council-member.svg';
 
 import testContent from '../../../__mocks__/data/testContent';
 
 import mapStatusDataToRoles from '../../utils/mapStatusDataToRoles';
 
 const rolesData = [
-    {
-      image: validatorsImage,
-      title: 'Validator',
-      to: '/roles#Validator',
-      key: 'validatorsCount',
-      hasLabel: false,
-    },
-    {
-      image: memberImage,
-      title: 'Council Member',
-      to: '/roles#Council-Member',
-      key: 'councilMembersCount',
-      hasLabel: false,
-    },
-    {
-      image: storageImage,
-      title: 'Storage Provider',
-      to: '/roles#Storage-Provider',
-      key: 'storageProviders',
-      hasLabel: true,
-    },
+  {
+    image: ValidatorsImage,
+    title: 'Validator',
+    to: '/roles#Validator',
+    key: 'validatorsCount',
+    hasLabel: false,
+  },
+  {
+    image: MemberImage,
+    title: 'Council Member',
+    to: '/roles#Council-Member',
+    key: 'councilMembersCount',
+    hasLabel: false,
+  },
+  {
+    image: StorageImage,
+    title: 'Storage Provider',
+    to: '/roles#Storage-Provider',
+    key: 'storageProviders',
+    hasLabel: true,
+  },
 ];
 
 storiesOf('Section|RoleList', module)

--- a/src/components/RoleOverview/FormResponse/index.js
+++ b/src/components/RoleOverview/FormResponse/index.js
@@ -4,6 +4,7 @@ import { bool, func } from 'prop-types';
 import Link from '../../Link';
 
 import { ReactComponent as CloseIcon } from '../../../assets/svg/close.svg';
+import { sharedData } from '../../../data/pages';
 
 import './style.scss';
 
@@ -35,12 +36,13 @@ const FormResponse = ({ error, onClose }) => {
         </p>
 
         <p className="FormResponse__text">
-          If you want to interact with us, or other people interested in this role, go to Telegram/RocketChat.
+          If you want to interact with us, or other people interested in this role, go to Telegram.
         </p>
 
         <p className="FormResponse__text">
           <strong>
-            For questions about this list, contact <Link href="mailto:hello@jsgenesis.com">hello@jsgenesis.com</Link>
+            For questions about this list, contact{' '}
+            <Link href={`mailto:${sharedData.defaultEmail}`}>{sharedData.defaultEmail}</Link>
           </strong>
         </p>
 

--- a/src/components/RoleOverview/roleOverview.stories.js
+++ b/src/components/RoleOverview/roleOverview.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import centered from '@storybook/addon-centered/react';
 
 import RoleOverview from './';
+import { sharedData } from '../../data/pages';
 
 import { ReactComponent as ValidatorImage } from '../../assets/svg/active-validators.svg';
 
@@ -29,7 +30,7 @@ const props = {
     'Hold sufficient amount of the native platform token to put at stake',
   ],
   tutorialLink: 'https://github.com/Joystream/helpdesk/tree/master/roles/validators',
-  questionLink: 'mailto:hello@jsgenesis.com',
+  questionLink: `mailto:${sharedData.defaultEmail}`,
   formAction: '',
 };
 

--- a/src/data/pages/athens.js
+++ b/src/data/pages/athens.js
@@ -58,16 +58,14 @@ const goals = [
   {
     title: 'Introduce platform memberships',
     text:
-      /* eslint-disable */
+      /* eslint-disable-next-line */
       'Although we are building an open blockchain in the sense that users are free to send tokens as they like, the Joystream experience is about having the platform users own, operate and govern the platform. We are agnostic on exactly what parts of the platform will be reserved for members, some actions will require and extra level of screening and accountability.',
-    /* eslint-disable */
   },
   {
     title: 'Build and release the storage node',
     text:
-      /* eslint-disable */
+      /* eslint-disable-next-line */
       'Although a storage node was built and used to host and distribute the platform content, it had some bugs making it unable to sync between clients and required a hardcoded liaison.',
-    /* eslint-disable */
     state: 'postponed',
   },
   {

--- a/src/data/pages/index.js
+++ b/src/data/pages/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ReactComponent as validatorsImage } from '../../assets/svg/active-validators.svg';
 import { ReactComponent as storageImage } from '../../assets/svg/platform-content-files.svg';
 import { ReactComponent as memberImage } from '../../assets/svg/council-member.svg';
@@ -11,7 +12,17 @@ import { ReactComponent as liveStreamingProviderImage } from '../../assets/svg/l
 import { ReactComponent as builderImage } from '../../assets/svg/builder.svg';
 import { ReactComponent as communicationModeratorImage } from '../../assets/svg/communication-moderator.svg';
 
-const roles = {
+export const sharedData = {
+  defaultEmail: 'hello@jsgenesis.com',
+  rolesDescription: (
+    <>
+      Explore available roles and pick the one that suits you the best. Influence the platform's development earning
+      Monero in the process.
+    </>
+  ),
+};
+
+export const roles = {
   active: [
     {
       image: validatorsImage,
@@ -79,5 +90,3 @@ const roles = {
     },
   ],
 };
-
-export { roles };

--- a/src/data/pages/roles.js
+++ b/src/data/pages/roles.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from '../../components/Link';
+import { sharedData } from '../../data/pages';
 import { ReactComponent as ValidatorImage } from '../../assets/svg/active-validators.svg';
 import { ReactComponent as CouncilMemberImage } from '../../assets/svg/council-member.svg';
 import { ReactComponent as StorageProviderImage } from '../../assets/svg/platform-content-files.svg';
@@ -38,9 +39,8 @@ const rolesData = {
         'Able to securely store keys hot keys',
         'Hold sufficient amount of the native platform token to put at stake',
       ],
-      tutorialLink:
-        'https://github.com/Joystream/helpdesk/tree/master/roles/validators',
-      questionLink: 'mailto:hello@jsgenesis.com',
+      tutorialLink: 'https://github.com/Joystream/helpdesk/tree/master/roles/validators',
+      questionLink: `mailto:${sharedData.defaultEmail}`,
       formAction: '',
     },
     {
@@ -55,7 +55,7 @@ const rolesData = {
       responsibilites: [
         'Discuss the meaning and merits of incoming proposals, covering a broad range of topics',
         'Vote on proposals',
-        'Represent the community members and your constituency to make day to day operations decisions',
+        'Represent the community members and your constituency to make day-to-day operations decisions',
       ],
       requirements: [
         `Proficient with basic data analysis and sufficient reputation and standing within
@@ -63,9 +63,8 @@ const rolesData = {
         'A deep understanding of the Joystream platform structure, function and resource allocation',
         'Hold sufficient amount of the native platform token to put at stake',
       ],
-      tutorialLink:
-        'https://github.com/Joystream/helpdesk/tree/master/roles/council-members',
-      questionLink: 'mailto:hello@jsgenesis.com',
+      tutorialLink: 'https://github.com/Joystream/helpdesk/tree/master/roles/council-members',
+      questionLink: `mailto:${sharedData.defaultEmail}`,
       formAction: '',
     },
     {
@@ -77,7 +76,7 @@ const rolesData = {
         but a separate set of storage and distribution nodes enabled uploading and downloading of
         such data. The storage provider is involved this activity, specifically storing large quantities of data.`,
       responsibilites: [
-        `Run an and maintain storage nodes that store very large quantities of static data,
+        `Run and maintain storage nodes that store very large quantities of static data,
         synchronize with other storage nodes, shares data with distributors, and accepts
         inbound uploads from end users`,
       ],
@@ -86,9 +85,8 @@ const rolesData = {
         'Access to highly performant and reliable IT infrastructure with high storage capacity',
         'Hold sufficient amount of the native platform token to put at stake',
       ],
-      tutorialLink:
-        'https://github.com/Joystream/helpdesk/tree/master/roles/storage-providers',
-      questionLink: 'mailto:hello@jsgenesis.com',
+      tutorialLink: 'https://github.com/Joystream/helpdesk/tree/master/roles/storage-providers',
+      questionLink: `mailto:${sharedData.defaultEmail}`,
       formAction: '',
     },
   ],
@@ -108,10 +106,9 @@ const rolesData = {
       responsibilites: [
         'Run and maintain screening nodes that are always available and performant',
         <>
-          Collaborate with{' '}
-          <Link href="#membership-curator">Membership Curators</Link> and
-          <Link href="#builder"> Builders</Link> to improve screening mechanisms
-          by discussing screening techniques, sharing traffic information
+          Collaborate with <Link href="#membership-curator">Membership Curators</Link> and
+          <Link href="#builder"> Builders</Link> to improve screening mechanisms by discussing screening techniques,
+          sharing traffic information
         </>,
         'Be responsive and reactive to changing circumstances',
       ],
@@ -130,13 +127,11 @@ const rolesData = {
       title: 'Membership Curator',
       overview: (
         <>
-          A membership is an integrated representation of identifying
-          information and associated activities of an actor on the platform. It
-          is possible to create memberships for free through the screeners,
-          described <Link href="#membership-screener"> above</Link>. Since this
-          invariably be an imperfect process, there must be some means by which
-          bad conduct and fake accounts can be disabled or removed. This is the
-          task of the membership curators.
+          A membership is an integrated representation of identifying information and associated activities of an actor
+          on the platform. It is possible to create memberships for free through the screeners, described{' '}
+          <Link href="#membership-screener"> above</Link>. Since this invariably be an imperfect process, there must be
+          some means by which bad conduct and fake accounts can be disabled or removed. This is the task of the
+          membership curators.
         </>
       ),
       responsibilites: [
@@ -144,9 +139,8 @@ const rolesData = {
         `Propose changes to status of memberships which are identified,
         and participate in any dispute process which may follow`,
         <>
-          Collaborate with <Link href="#membership-screener"> Screeners</Link>{' '}
-          and <Link href="#builder"> Builders</Link> to improve tools for
-          identifying such members
+          Collaborate with <Link href="#membership-screener"> Screeners</Link> and{' '}
+          <Link href="#builder"> Builders</Link> to improve tools for identifying such members
         </>,
       ],
       requirements: [
@@ -173,9 +167,8 @@ const rolesData = {
         'Adjudicate possible dispute processes resulting from reports from users',
         'Update information on content to be accurate',
         <>
-          Collaborate with <Link href="#builder"> Builders</Link> to improve
-          both tools, and user facing experiences, to improve the integrity of
-          the content directory
+          Collaborate with <Link href="#builder"> Builders</Link> to improve both tools, and user facing experiences, to
+          improve the integrity of the content directory
         </>,
       ],
       requirements: [
@@ -210,8 +203,8 @@ const rolesData = {
       The bandwidth provider is involved this activity,
         specifically distributing static data to end users at scale.`,
       responsibilites: [
-        'Run and maintain distributor nodes that delivers large volumes of upstream data to a ' +
-          'large number of simultaneous end users',
+        'Run and maintain distributor nodes that deliver large volumes of upstream data to a large number ' +
+          'of simultaneous end users',
       ],
       requirements: [
         'Experienced with how to setup and maintain high performance IT infrastructure',
@@ -236,9 +229,8 @@ const rolesData = {
         `Run and maintain discovery nodes that respond to discovery related queries by staying in
         sync with the content directory, and applying local ranking heuristics.`,
         <>
-          Collaborate with <Link href="#builder">Builders</Link> to improve both
-          tools, and user facing experiences, to improve the discovery
-          experience
+          Collaborate with <Link href="#builder">Builders</Link> to improve both tools, and user facing experiences, to
+          improve the discovery experience
         </>,
       ],
       requirements: [
@@ -257,8 +249,8 @@ const rolesData = {
       The live streaming providers are responsible for directly, or indirectly from peer
       providers, taking a (transcoded) stream from the source publisher, and relaying it to end users.`,
       responsibilites: [
-        `Run and maintain live streaming nodes that delivers large volumes of upstream data to a large number of
-         simultaneous end users`,
+        'Run and maintain live streaming nodes that deliver large volumes of upstream data to a large number ' +
+          'of simultaneous end users',
       ],
       requirements: [
         'Experienced with how to setup and maintain high performance IT infrastructure',
@@ -274,32 +266,26 @@ const rolesData = {
       title: 'Builder',
       overview: (
         <>
-          The platform runtime, tools, infrastructure software and user facing
-          applications are all meant to evolve over time. A diverse set of
-          contributors are required to facilitate this, including
+          The platform runtime, tools, infrastructure software and user facing applications are all meant to evolve over
+          time. A diverse set of contributors are required to facilitate this, including
           <br />
           <br />
           <ul className="RoleOverview__dashList">
             <li>
-              <strong>Developers:</strong> Software developers, Data scientists,
-              DevOps and QA
+              <strong>Developers:</strong> Software developers, Data scientists, DevOps and QA
             </li>
             <li>
-              <strong>Designers:</strong> Web, Mobile, UX/UI, Branding and
-              Visual Design
+              <strong>Designers:</strong> Web, Mobile, UX/UI, Branding and Visual Design
             </li>
             <li>
-              <strong>Product Managers:</strong> Digital Product Managers,
-              Product Owners and Analysts
+              <strong>Product Managers:</strong> Digital Product Managers, Product Owners and Analysts
             </li>
           </ul>
           <br />
-          All of these contributors are collectively referred to as Builders.
-          Anyone can contribute in the same mode as any of these possible
-          contributor functions, as all the platform source assets are open
-          source and developed in the open. Being a Builder means that one has
-          some scope of responsibility in ongoing efforts, and that one has some
-          predefined reward scheme associated with this responsibility.
+          All of these contributors are collectively referred to as Builders. Anyone can contribute in the same mode as
+          any of these possible contributor functions, as all the platform source assets are open source and developed
+          in the open. Being a Builder means that one has some scope of responsibility in ongoing efforts, and that one
+          has some predefined reward scheme associated with this responsibility.
         </>
       ),
       responsibilites: [

--- a/src/data/pages/sparta.js
+++ b/src/data/pages/sparta.js
@@ -45,7 +45,7 @@ const goals = [
     text: (
       <>
         As a "user governed media platform", allowing users to elect{' '}
-        <Link to="/roles#council-member">Council Members</Link> to represent their interest in day to day operations was
+        <Link to="/roles#council-member">Council Members</Link> to represent their interest in day-to-day operations was
         a major goal for us.
       </>
     ),

--- a/src/pages/acropolis/index.js
+++ b/src/pages/acropolis/index.js
@@ -29,7 +29,7 @@ import { ReactComponent as ReleaseImg } from '../../assets/svg/release-doc.svg';
 import { ReactComponent as PersonIcon } from '../../assets/svg/person.svg';
 import AcropolisImg from '../../assets/svg/acropolis-building.svg';
 
-import { roles } from '../../data/pages';
+import { sharedData, roles } from '../../data/pages';
 import { goalsData } from '../../data/pages/acropolis';
 
 import './style.scss';
@@ -39,10 +39,7 @@ const AcropolisPage = ({ content }) => {
 
   return (
     <BaseLayout>
-      <SiteMetadata
-        title="Joystream: A user governed video platform"
-        description="Explore the upcoming Acropolis Testnet"
-      />
+      <SiteMetadata title="Joystream: A user governed video platform" description="Explore the Acropolis Testnet" />
 
       <Hero
         image={acropolisImage}
@@ -51,10 +48,7 @@ const AcropolisPage = ({ content }) => {
         chip={<Chip onClick={() => setModalClosed(true)}>What is this?</Chip>}
         animationStartValue={0}
       >
-        <p className="AcropolisPage__hero-paragraph">
-          Explore available roles and pick the one that suits you the most. Influence platforms development earning
-          Monero in the process.
-        </p>
+        <p className="AcropolisPage__hero-paragraph">{sharedData.rolesDescription}</p>
         <HeroCard date="2019/06/27 17:50" />
 
         <TestnetModal

--- a/src/pages/athens/index.js
+++ b/src/pages/athens/index.js
@@ -29,6 +29,7 @@ import { ReactComponent as PersonIcon } from '../../assets/svg/person.svg';
 import AthensOwlImg from '../../assets/svg/athens-owl.svg';
 
 import { analytics, roles, goals } from '../../data/pages/athens';
+import { sharedData } from '../../data/pages';
 
 import './style.scss';
 
@@ -37,7 +38,7 @@ const AthensPage = ({ content }) => {
 
   return (
     <BaseLayout>
-      <SiteMetadata title="Joystream: A user governed video platform" description="Explore the live Athens testnet" />
+      <SiteMetadata title="Joystream: A user governed video platform" description="Explore Athens testnet" />
 
       <Hero
         image={athensImage}
@@ -46,10 +47,7 @@ const AthensPage = ({ content }) => {
         chip={<Chip onClick={() => setModalClosed(true)}>What is this?</Chip>}
         animationStartValue={0}
       >
-        <p className="AthensPage__hero-paragraph">
-          Explore available roles and pick the one that suits you the most. Influence platforms development earning
-          Monero in the process.
-        </p>
+        <p className="AthensPage__hero-paragraph">{sharedData.rolesDescription}</p>
         <HeroCard
           info
           date="2019/06/24 17:50"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,16 +29,23 @@ import { roles } from '../data/pages';
 
 import './style.scss';
 
+const activeTestnet = {
+  name: 'Acropolis',
+  incentivesLink: 'https://blog.joystream.org/acropolis-incentives/',
+};
+
 const IndexPage = ({ content }) => (
   <BaseLayout>
     <SiteMetadata
       title="Joystream: A user governed video platform"
-      description="Earn monero to participate on our testnets!"
+      description="Earn monero for participating on our testnets!"
     />
     <Hero image={platformImage} title="A user governed video platform" animationStartValue={0}>
-      <p className="IndexPage__hero-paragraph">Earn Monero by participating in the current Athens testnet</p>
+      <p className="IndexPage__hero-paragraph">
+        Earn Monero by participating in the current {activeTestnet.name} testnet
+      </p>
       <div className="IndexPage__hero-group">
-        <Button secondary className="IndexPage__hero-button" href="https://blog.joystream.org/acropolis-incentives/">
+        <Button secondary className="IndexPage__hero-button" href={activeTestnet.incentivesLink}>
           Earn Monero
         </Button>
         <Button secondary reversed className="IndexPage__hero-button" href="https://testnet.joystream.org/">
@@ -49,7 +56,7 @@ const IndexPage = ({ content }) => (
 
     <LayoutWrapper>
       <TestnetItem
-        title="Acropolis Tesnet"
+        title="Acropolis Testnet"
         image={AcropolisImage}
         children={
           <>
@@ -58,13 +65,13 @@ const IndexPage = ({ content }) => (
           </>
         }
         button={{
-          label: 'Explore acropolis',
+          label: 'Explore Acropolis',
           to: '/acropolis',
         }}
       />
 
       <Analytics content={mapStatusDataToAnalytics(content)}>
-        <Button secondary href="https://blog.joystream.org/athens-incentives/">
+        <Button secondary href={activeTestnet.incentivesLink}>
           Participate and Earn Monero
         </Button>
       </Analytics>

--- a/src/pages/roles/index.js
+++ b/src/pages/roles/index.js
@@ -11,6 +11,7 @@ import SiteMetadata from '../../components/SiteMetadata';
 
 import rolesImage from '../../assets/svg/roles-hero.svg';
 
+import { sharedData } from '../../data/pages';
 import { rolesData } from '../../data/pages/roles';
 
 import './style.scss';
@@ -38,26 +39,15 @@ const RolesPage = () => {
         description="Read more about current and future roles on the Joystream Platform."
       />
 
-      <Hero
-        image={rolesImage}
-        title="Discover various roles on the platform"
-        animationStartValue={0}
-      >
-        <p className="RolesPage__hero-paragraph">
-          Explore available roles and pick the one that suits you the most.
-          Influence platforms development earning Monero in the process.
-        </p>
+      <Hero image={rolesImage} title="Discover various roles on the platform" animationStartValue={0}>
+        <p className="RolesPage__hero-paragraph">{sharedData.rolesDescription}</p>
       </Hero>
 
       <LayoutWrapper gradient>
-        <Sidebar
-          onElementChange={scrollToElement}
-          currentElement={elementInViewport}
-          data={rolesData}
-        />
+        <Sidebar onElementChange={scrollToElement} currentElement={elementInViewport} data={rolesData} />
         <div className="RoleOverview__Wrapper">
-          {Object.keys(rolesData).map(key =>
-            rolesData[key].map(role => (
+          {Object.keys(rolesData).map(key => {
+            return rolesData[key].map(role => (
               <InView
                 as="div"
                 threshold={0.2}
@@ -70,7 +60,8 @@ const RolesPage = () => {
               >
                 <RoleOverview {...role} type={key} ref={elementsRef[role.id]} />
               </InView>
-            )))}
+            ));
+          })}
         </div>
       </LayoutWrapper>
     </BaseLayout>

--- a/src/pages/sparta/index.js
+++ b/src/pages/sparta/index.js
@@ -28,6 +28,16 @@ import { analytics, roles, goals } from '../../data/pages/sparta';
 
 import './style.scss';
 
+const heroMarkdownContent = `
+  ### FAILURE IDENTIFIED
+
+  On Friday the 29th of March, the Sparta network went down due to a 
+  [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) 
+  that we had not pulled down before release. 
+  
+  More details can be found in this [blog post](https://blog.joystream.org/sparta-sacked/).
+`;
+
 const SpartaPage = ({ content }) => {
   const [isModalOpen, setModalOpen] = useState(false);
 
@@ -45,19 +55,10 @@ const SpartaPage = ({ content }) => {
         chip={<Chip onClick={() => setModalOpen(true)}>What is this?</Chip>}
       >
         <p className="SpartaPage__hero-paragraph">
-          Explore available roles and pick the one that suits you the most. Influence platforms development earning
-          Monero in the process.
+          Explore available roles and pick the one that suits you the most.
+          Influence platforms development earning Monero in the process.
         </p>
-        <HeroCard
-          error /* eslint-disable */
-          content={`
-  ### FAILURE IDENTIFIED
-  On Friday the 29th of March, the Sparta network went down due to a [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) that we had not pulled down before release.
-
-  More details can be found in this [blog post](https://blog.joystream.org/sparta-sacked/).
-  `}
-          /* eslint-enable */
-        />
+        <HeroCard error content={heroMarkdownContent} />
 
         <TestnetModal
           title="Helmet of Sparta"
@@ -66,23 +67,30 @@ const SpartaPage = ({ content }) => {
           isOpen={isModalOpen}
         >
           <p>
-            <strong>The Spartan army helmet</strong> represents what Sparta is most known for today, their military
-            might. For it's time, it was also known for its advanced governance system.
+            <strong>The Spartan army helmet</strong> represents what Sparta is
+            most known for today, their military might. For it's time, it was
+            also known for its advanced governance system.
           </p>
         </TestnetModal>
       </Hero>
 
       <LayoutWrapper>
-        <TitleWrapper title="Network Statistics" subtitle="As they were at the end of the network.">
-          <Analytics content={mapStatusDataToAnalytics(content)} items={analytics} />
+        <TitleWrapper
+          title="Network Statistics"
+          subtitle="As they were at the end of the network."
+        >
+          <Analytics
+            content={mapStatusDataToAnalytics(content)}
+            items={analytics}
+          />
         </TitleWrapper>
 
         <TitleWrapper
           title="Testnet Goals"
           subtitle={
             <>
-              The goals below is a simplified and qualitative representation of the Key Results listed in our release
-              OKR.
+              The goals below is a simplified and qualitative representation of
+              the Key Results listed in our release OKR.
             </>
           }
         >
@@ -93,22 +101,25 @@ const SpartaPage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Roles available on the Sparta testnet">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList
+              roles={roles.active}
+              content={mapStatusDataToRoles(content)}
+            />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>
 
       <MapInfo title="The city of Sparta" location="sparta">
         <p>
-          <strong>Sparta was a prominent city-state in Ancient Greece.</strong> In addition to its military might, it
-          was also unique both for its time and compared to its greek rivals due its defined social system and
-          constitution.
+          <strong>Sparta was a prominent city-state in Ancient Greece.</strong>{' '}
+          In addition to its military might, it was also unique both for its
+          time and compared to its greek rivals due its defined social system
+          and constitution.
           <br />
           <br />
-          We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law,
-          however draconian by modern standard.
-          <br />
-          <br />
+          We chose the name Sparta due to it's historical significance in the
+          path towards democracy and rule of law, however draconian by modern
+          standard.
         </p>
       </MapInfo>
     </BaseLayout>

--- a/src/pages/sparta/index.js
+++ b/src/pages/sparta/index.js
@@ -25,6 +25,7 @@ import spartaImage from '../../assets/svg/sparta.svg';
 import SpartaHelmetImg from '../../assets/svg/sparta-helmet.svg';
 
 import { analytics, roles, goals } from '../../data/pages/sparta';
+import { sharedData } from '../../data/pages';
 
 import './style.scss';
 
@@ -54,10 +55,7 @@ const SpartaPage = ({ content }) => {
         indent
         chip={<Chip onClick={() => setModalOpen(true)}>What is this?</Chip>}
       >
-        <p className="SpartaPage__hero-paragraph">
-          Explore available roles and pick the one that suits you the most.
-          Influence platforms development earning Monero in the process.
-        </p>
+        <p className="SpartaPage__hero-paragraph">{sharedData.rolesDescription}</p>
         <HeroCard error content={heroMarkdownContent} />
 
         <TestnetModal
@@ -67,30 +65,23 @@ const SpartaPage = ({ content }) => {
           isOpen={isModalOpen}
         >
           <p>
-            <strong>The Spartan army helmet</strong> represents what Sparta is
-            most known for today, their military might. For it's time, it was
-            also known for its advanced governance system.
+            <strong>The Spartan army helmet</strong> represents what Sparta is most known for today, their military
+            might. For it's time, it was also known for its advanced governance system.
           </p>
         </TestnetModal>
       </Hero>
 
       <LayoutWrapper>
-        <TitleWrapper
-          title="Network Statistics"
-          subtitle="As they were at the end of the network."
-        >
-          <Analytics
-            content={mapStatusDataToAnalytics(content)}
-            items={analytics}
-          />
+        <TitleWrapper title="Network Statistics" subtitle="As they were at the end of the network.">
+          <Analytics content={mapStatusDataToAnalytics(content)} items={analytics} />
         </TitleWrapper>
 
         <TitleWrapper
           title="Testnet Goals"
           subtitle={
             <>
-              The goals below is a simplified and qualitative representation of
-              the Key Results listed in our release OKR.
+              The goals below is a simplified and qualitative representation of the Key Results listed in our release
+              OKR.
             </>
           }
         >
@@ -101,25 +92,20 @@ const SpartaPage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Roles available on the Sparta testnet">
           <ColumnsLayout>
-            <RoleList
-              roles={roles.active}
-              content={mapStatusDataToRoles(content)}
-            />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>
 
       <MapInfo title="The city of Sparta" location="sparta">
         <p>
-          <strong>Sparta was a prominent city-state in Ancient Greece.</strong>{' '}
-          In addition to its military might, it was also unique both for its
-          time and compared to its greek rivals due its defined social system
-          and constitution.
+          <strong>Sparta was a prominent city-state in Ancient Greece.</strong> In addition to its military might, it
+          was also unique both for its time and compared to its greek rivals due its defined social system and
+          constitution.
           <br />
           <br />
-          We chose the name Sparta due to it's historical significance in the
-          path towards democracy and rule of law, however draconian by modern
-          standard.
+          We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law,
+          however draconian by modern standard.
         </p>
       </MapInfo>
     </BaseLayout>


### PR DESCRIPTION
- add `printWidth` to keep settings consistent between eslint and prettier
- update incorrect prop-types
- modify svg mock to work with both path and component imports
- keep enzyme config in a single setup file
- fix RoleCard and RoleList storybook stories
- update formatting on sparta page to avoid using `eslint-disable`